### PR TITLE
Changes to make radagast work with Clojure 1.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,2 @@
 (defproject radagast "1.1.0"
-  :description "Simplistic test coverage."
-  :dev-dependencies [[org.clojure/clojure "1.2.0"]
-                     [org.clojure/clojure-contrib "1.2.0"]])
+  :description "Simplistic test coverage.")

--- a/src/radagast/coverage.clj
+++ b/src/radagast/coverage.clj
@@ -1,7 +1,7 @@
 (ns radagast.coverage
   (:require [clojure.test]))
 
-(def *ns-must-match* nil)
+(def ^{:dynamic true} *ns-must-match* nil)
 
 (defn skip-ns? [n]
   (or (re-find #"(^clojure\.|radagast)" (str (.getName n)))


### PR DESCRIPTION
I've done two things here:
- Removed Clojure and old contrib dependencies from `project.clj`. No version-specific functionality is in the code, and as a dev-dependency on other projects, Clojure should already be there.
- Add `^{:dynamic true}` to the one dynamic var in the code base.
