### PR TITLE
Fix README listed version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ rely on Radagast to tell you if your tests are good!
 For now it only works as a Leiningen plugin. Include it as a
 dev-dependency in your project.clj:
 
-    :dev-dependencies [[radagast "1.1.1"]]
+    :dev-dependencies [[radagast "1.2.1"]]
 
 Then you can use it:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ rely on Radagast to tell you if your tests are good!
 For now it only works as a Leiningen plugin. Include it as a
 dev-dependency in your project.clj:
 
-    :dev-dependencies [[radagast "1.2.1"]]
+```clojure
+:profiles {:dev {:dependencies [[radagast "1.2."]]}}
+```
 
 Then you can use it:
 


### PR DESCRIPTION
Because 1.1.1 isn't updated for lein 2.0.0 and dies, this being a source of user confusion.
