### PR TITLE
Neither of us can read

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For now it only works as a Leiningen plugin. Include it as a
 dev-dependency in your project.clj:
 
 ```clojure
-:profiles {:dev {:dependencies [[radagast "1.2."]]}}
+:profiles {:dev {:dependencies [[radagast "1.2.1"]]}}
 ```
 
 Then you can use it:


### PR DESCRIPTION
Evidently neither of us read very carfully, the current README says 'radagst "1.2."' which is silly. This commit corrects for the aforementioned silly behavior.
